### PR TITLE
Change command input to be lowercase

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -43,7 +43,7 @@ public class AddressBookParser {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
         }
 
-        final String commandWord = matcher.group("commandWord");
+        final String commandWord = matcher.group("commandWord").toLowerCase();
         final String arguments = matcher.group("arguments");
 
         // Note to developers: Change the log level in config.json to enable lower level (i.e., FINE, FINER and lower)


### PR DESCRIPTION
Fixes #43 

The original address book does not understand the command when the user types "List" or "DELETE" or "LiSt", etc

The new change converts the input of the command (ie. ONLY the command word eg. "add", "list" and not the rest of the input) to lowercase so that TP can undestand the input even if user types in uppercase