### PR TITLE
Add message when list is empty

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -17,12 +17,16 @@ public class ListCommand extends Command {
             + "Example: " + COMMAND_WORD;
 
     public static final String MESSAGE_SUCCESS = "Listed all persons";
+    public static final String MESSAGE_NO_RESULT = "There is.. no one?";
 
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        if (model.getFilteredPersonList().isEmpty()) {
+            return new CommandResult(MESSAGE_NO_RESULT);
+        }
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }


### PR DESCRIPTION
Fixes #55 

When we use the list command AND there is no one in the list, it will return the message "Listed all persons"

Let's change it such that it returns "There is.. no one?" so that the user knows that there is really no one in the list and is not facing a bug