### PR TITLE
Fixed failing tests for FindCommand and FindCommandParser

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -22,19 +22,9 @@ public class FindCommand extends Command {
             + "At least one parameter must be provided.\n"
             + "Example: " + COMMAND_WORD + " /n John Doe /id A1234567E";
 
-    //    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
-    //            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
-    //            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-    //            + "Example: " + COMMAND_WORD + " alice bob charlie";
-
-    //    private final NameContainsKeywordsPredicate predicate;
-
     private final Predicate<Person> predicate;
 
 
-    //    public FindCommand(NameContainsKeywordsPredicate predicate) {
-    //        this.predicate = predicate;
-    //    }
     public FindCommand(Predicate<Person> predicate) {
         this.predicate = predicate;
     }
@@ -53,21 +43,22 @@ public class FindCommand extends Command {
 
     @Override
     public boolean equals(Object other) {
-        //        if (other == this) {
-        //            return true;
-        //        }
-        //
-        //        // instanceof handles nulls
-        //        if (!(other instanceof FindCommand)) {
-        //            return false;
-        //        }
-        //
-        //        FindCommand otherFindCommand = (FindCommand) other;
-        //        return predicate.equals(otherFindCommand.predicate);
-        return other == this // Short circuit if same object
-                || (other instanceof FindCommand // instanceof handles nulls
-                && predicate.equals(((FindCommand) other).predicate)); // State check
+        if (this == other) {
+            return true;
+        }
+
+        if (!(other instanceof FindCommand)) {
+            return false;
+        }
+        FindCommand that = (FindCommand) other;
+        return predicate.equals(that.predicate);
     }
+
+    @Override
+    public int hashCode() {
+        return predicate.hashCode();
+    }
+
 
     @Override
     public String toString() {

--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -45,13 +45,29 @@ public class ArgumentTokenizer {
      * {@see findAllPrefixPositions}
      */
     private static List<PrefixPosition> findPrefixPositions(String argsString, Prefix prefix) {
+
+        //        List<PrefixPosition> positions = new ArrayList<>();
+        //
+        //        int prefixPosition = findPrefixPosition(argsString, prefix.getPrefix(), 0);
+        //        while (prefixPosition != -1) {
+        //            PrefixPosition extendedPrefix = new PrefixPosition(prefix, prefixPosition);
+        //            positions.add(extendedPrefix);
+        //            prefixPosition = findPrefixPosition(argsString, prefix.getPrefix(), prefixPosition);
+        //        }
+        //
+        //        return positions;
+
         List<PrefixPosition> positions = new ArrayList<>();
 
-        int prefixPosition = findPrefixPosition(argsString, prefix.getPrefix(), 0);
+        int fromIndex = 0;
+        int prefixPosition = findPrefixPosition(argsString, prefix.getPrefix(), fromIndex);
         while (prefixPosition != -1) {
             PrefixPosition extendedPrefix = new PrefixPosition(prefix, prefixPosition);
             positions.add(extendedPrefix);
-            prefixPosition = findPrefixPosition(argsString, prefix.getPrefix(), prefixPosition);
+
+            // Update fromIndex to move past the current prefix
+            fromIndex = prefixPosition + prefix.getPrefix().length();
+            prefixPosition = findPrefixPosition(argsString, prefix.getPrefix(), fromIndex);
         }
 
         return positions;
@@ -70,9 +86,19 @@ public class ArgumentTokenizer {
      * {@code fromIndex} = 0, this method returns 5.
      */
     private static int findPrefixPosition(String argsString, String prefix, int fromIndex) {
-        int prefixIndex = argsString.indexOf(" " + prefix, fromIndex);
-        return prefixIndex == -1 ? -1
-                : prefixIndex + 1; // +1 as offset for whitespace
+        //        int prefixIndex = argsString.indexOf(" " + prefix, fromIndex);
+        //        return prefixIndex == -1 ? -1
+        //                : prefixIndex + 1; // +1 as offset for whitespace
+        int prefixIndex = argsString.indexOf(prefix, fromIndex);
+        while (prefixIndex != -1) {
+            // Check if the prefix is at the start or preceded by whitespace
+            if (prefixIndex == 0 || Character.isWhitespace(argsString.charAt(prefixIndex - 1))) {
+                return prefixIndex;
+            }
+            // Move to the next occurrence
+            prefixIndex = argsString.indexOf(prefix, prefixIndex + 1);
+        }
+        return -1;
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -4,13 +4,12 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.function.Predicate;
 
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.CompositePredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
-import seedu.address.model.person.Person;
 import seedu.address.model.person.StudentIdMatchesPredicate;
 
 /**
@@ -30,16 +29,6 @@ public class FindCommandParser implements Parser<FindCommand> {
      */
     @Override
     public FindCommand parse(String args) throws ParseException {
-        //        String trimmedArgs = args.trim();
-        //        if (trimmedArgs.isEmpty()) {
-        //            throw new ParseException(
-        //                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
-        //        }
-        //
-        //        String[] nameKeywords = trimmedArgs.split("\\s+");
-        //
-        //        return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
-        //    }
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_STUDENT_ID);
 
@@ -51,7 +40,7 @@ public class FindCommandParser implements Parser<FindCommand> {
         // Check for duplicate prefixes
         verifyNoDuplicatePrefixes(argMultimap, PREFIX_NAME, PREFIX_STUDENT_ID);
 
-        Predicate<Person> combinedPredicate = person -> true;
+        CompositePredicate combinedPredicate = new CompositePredicate();
 
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
             String nameInput = argMultimap.getValue(PREFIX_NAME).get();
@@ -59,13 +48,13 @@ public class FindCommandParser implements Parser<FindCommand> {
 
             // Use the nameInput as a single keyword for partial matching
             List<String> nameKeywords = Arrays.asList(nameInput.trim());
-            combinedPredicate = combinedPredicate.and(new NameContainsKeywordsPredicate(nameKeywords));
+            combinedPredicate.addPredicate(new NameContainsKeywordsPredicate(nameKeywords));
         }
 
         if (argMultimap.getValue(PREFIX_STUDENT_ID).isPresent()) {
             String studentIdInput = argMultimap.getValue(PREFIX_STUDENT_ID).get();
             validateStudentId(studentIdInput);
-            combinedPredicate = combinedPredicate.and(new StudentIdMatchesPredicate(studentIdInput));
+            combinedPredicate.addPredicate(new StudentIdMatchesPredicate(studentIdInput));
         }
 
         return new FindCommand(combinedPredicate);

--- a/src/main/java/seedu/address/model/person/CompositePredicate.java
+++ b/src/main/java/seedu/address/model/person/CompositePredicate.java
@@ -1,0 +1,47 @@
+package seedu.address.model.person;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * Represents a composite predicate that combines multiple predicates into one.
+ */
+public class CompositePredicate implements Predicate<Person> {
+    private final List<Predicate<Person>> predicates;
+
+    public CompositePredicate() {
+        this.predicates = new ArrayList<>();
+    }
+
+    public void addPredicate(Predicate<Person> predicate) {
+        predicates.add(predicate);
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return predicates.stream().allMatch(predicate -> predicate.test(person));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (!(other instanceof CompositePredicate)) {
+            return false;
+        }
+        CompositePredicate that = (CompositePredicate) other;
+        return predicates.equals(that.predicates);
+    }
+
+    @Override
+    public int hashCode() {
+        return predicates.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "CompositePredicate{" + "predicates=" + predicates + '}';
+    }
+}

--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -23,8 +23,6 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
         return keywords.stream()
                 .map(String::toLowerCase)
                 .anyMatch(keyword -> fullNameLowerCase.contains(keyword));
-//        return keywords.stream()
-//                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getName().fullName, keyword));
     }
 
     @Override
@@ -33,17 +31,6 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
         return other == this
                 || (other instanceof NameContainsKeywordsPredicate
                 && keywords.equals(((NameContainsKeywordsPredicate) other).keywords));
-//        if (other == this) {
-//            return true;
-//        }
-//
-//        // instanceof handles nulls
-//        if (!(other instanceof NameContainsKeywordsPredicate)) {
-//            return false;
-//        }
-//
-//        NameContainsKeywordsPredicate otherNameContainsKeywordsPredicate = (NameContainsKeywordsPredicate) other;
-//        return keywords.equals(otherNameContainsKeywordsPredicate.keywords);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/StudentIdMatchesPredicate.java
+++ b/src/main/java/seedu/address/model/person/StudentIdMatchesPredicate.java
@@ -1,7 +1,5 @@
 package seedu.address.model.person;
 
-//public class StudentIdMatchesPredicate {
-//}
 import java.util.function.Predicate;
 
 /**

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -12,6 +12,7 @@ import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -20,6 +21,8 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.StudentIdMatchesPredicate;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
@@ -31,10 +34,9 @@ public class FindCommandTest {
 
     @Test
     public void equals() {
-        NameContainsKeywordsPredicate firstPredicate =
-                new NameContainsKeywordsPredicate(Collections.singletonList("first"));
-        NameContainsKeywordsPredicate secondPredicate =
-                new NameContainsKeywordsPredicate(Collections.singletonList("second"));
+        // Single predicate (Name)
+        Predicate<Person> firstPredicate = new NameContainsKeywordsPredicate(Collections.singletonList("first"));
+        Predicate<Person> secondPredicate = new NameContainsKeywordsPredicate(Collections.singletonList("second"));
 
         FindCommand findFirstCommand = new FindCommand(firstPredicate);
         FindCommand findSecondCommand = new FindCommand(secondPredicate);
@@ -52,14 +54,28 @@ public class FindCommandTest {
         // null -> returns false
         assertFalse(findFirstCommand.equals(null));
 
-        // different person -> returns false
+        // different predicate -> returns false
         assertFalse(findFirstCommand.equals(findSecondCommand));
+
+        // Combined predicate (Name and Student ID)
+        Predicate<Person> combinedPredicateFirst = new NameContainsKeywordsPredicate(
+                Collections.singletonList("first"))
+                .and(new StudentIdMatchesPredicate("A1234567E"));
+        Predicate<Person> combinedPredicateSecond = new NameContainsKeywordsPredicate(
+                Collections.singletonList("first"))
+                .and(new StudentIdMatchesPredicate("A7654321E"));
+
+        FindCommand findCombinedFirstCommand = new FindCommand(combinedPredicateFirst);
+        FindCommand findCombinedSecondCommand = new FindCommand(combinedPredicateSecond);
+
+        // different combined predicates -> returns false
+        assertFalse(findCombinedFirstCommand.equals(findCombinedSecondCommand));
     }
 
     @Test
     public void execute_zeroKeywords_noPersonFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
-        NameContainsKeywordsPredicate predicate = preparePredicate(" ");
+        Predicate<Person> predicate = preparePredicate(" ");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -69,7 +85,7 @@ public class FindCommandTest {
     @Test
     public void execute_multipleKeywords_multiplePersonsFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
-        NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
+        Predicate<Person> predicate = preparePredicate("Kurz Elle Kunz");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -85,9 +101,10 @@ public class FindCommandTest {
     }
 
     /**
-     * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
+     * Parses {@code userInput} into a {@code StudentIdMatchesPredicate}.
      */
-    private NameContainsKeywordsPredicate preparePredicate(String userInput) {
+    private Predicate<Person> preparePredicate(String userInput) {
         return new NameContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
     }
+
 }

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_NAME_CANNOT_BE_EMPTY;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -9,26 +10,61 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindCommand;
+import seedu.address.model.person.CompositePredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.StudentIdMatchesPredicate;
 
 public class FindCommandParserTest {
 
     private FindCommandParser parser = new FindCommandParser();
 
     @Test
-    public void parse_emptyArg_throwsParseException() {
-        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+    public void parse_missingPrefixes_throwsParseException() {
+        // No prefixes provided
+        assertParseFailure(parser, "Alice Bob",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
     }
 
     @Test
-    public void parse_validArgs_returnsFindCommand() {
-        // no leading and trailing whitespaces
-        FindCommand expectedFindCommand =
-                new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
-        assertParseSuccess(parser, "Alice Bob", expectedFindCommand);
+    public void parse_emptyArg_throwsParseException() {
+        // Empty input
+        assertParseFailure(parser, "     ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+    }
 
-        // multiple whitespaces between keywords
-        assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindCommand);
+    @Test
+    public void parse_validNameArg_returnsFindCommand() {
+        // Valid name search
+        CompositePredicate predicate = new CompositePredicate();
+        predicate.addPredicate(new NameContainsKeywordsPredicate(Arrays.asList("Alice")));
+        FindCommand expectedFindCommand = new FindCommand(predicate);
+        assertParseSuccess(parser, "/n Alice", expectedFindCommand);
+    }
+
+    @Test
+    public void parse_validStudentIdArg_returnsFindCommand() {
+        // Valid student ID search
+        CompositePredicate predicate = new CompositePredicate();
+        predicate.addPredicate(new StudentIdMatchesPredicate("A1234567E"));
+        FindCommand expectedFindCommand = new FindCommand(predicate);
+        assertParseSuccess(parser, "/id A1234567E", expectedFindCommand);
+    }
+
+    @Test
+    public void parse_validCombinedArgs_returnsFindCommand() {
+        // Valid combined search
+        CompositePredicate predicate = new CompositePredicate();
+        predicate.addPredicate(new NameContainsKeywordsPredicate(Arrays.asList("Alice")));
+        predicate.addPredicate(new StudentIdMatchesPredicate("A1234567E"));
+        FindCommand expectedFindCommand = new FindCommand(predicate);
+        assertParseSuccess(parser, "/n Alice /id A1234567E", expectedFindCommand);
+    }
+    @Test
+    public void parse_emptyName_throwsParseException() {
+        // Empty name
+        assertParseFailure(parser, "/n ",
+                MESSAGE_NAME_CANNOT_BE_EMPTY);
     }
 
 }
+


### PR DESCRIPTION
Closes #62 

This PR addresses several issues related to test failures and the handling of multiple argument types in the `FindCommand`. The following changes were made:

#### 1. **Tests:**
   - Fixed failing tests in `FindCommandTest` and `FindCommandParserTest` that were not running or passing due to issues with the prefix handling and predicate logic.
   - Added comprehensive test cases to ensure proper functionality for both `/n name` and `/id studentId` searches.

#### 2. **ArgumentTokenizer:**
   - Updated the `ArgumentTokenizer` to accept prefixes without requiring a preceding whitespace. This resolves an issue where the tokenizer would only recognize prefixes like ` /n`, and now handles `/n` without the leading space.

#### 3. **Composite Predicate Implementation:**
   - Introduced a Composite Predicate in `FindCommandParser` to support searches based on multiple criteria (e.g., name and student ID). This allows the parser to process commands that include multiple arguments, such as `/n` for name and `/id` for student ID, in a single command.

#### 4. **Cleaned Up Comments:**
   - Improved readability and maintainability by cleaning up outdated or unclear comments in the `FindCommandParser` and related classes.