### PR TITLE
Add show command to display members in a group

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ShowCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ShowCommand.java
@@ -1,0 +1,71 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+
+/**
+ * Shows all students in the address book who are in the same group.
+ */
+public class ShowCommand extends Command {
+
+    public static final String COMMAND_WORD = "show";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows all students in the same group "
+            + "and displays them as a list with index numbers.\n"
+            + "Parameters: NUMBER\n"
+            + "only one number must be provided.\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
+
+    private final Predicate<Person> predicate;
+
+    public ShowCommand(Predicate<Person> predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredPersonList(predicate);
+        int matchedStudents = model.getFilteredPersonList().size();
+
+        if (matchedStudents == 0) {
+            return new CommandResult(Messages.MESSAGE_NO_STUDENTS_FOUND);
+        }
+        return new CommandResult(String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, matchedStudents));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof ShowCommand)) {
+            return false;
+        }
+
+        ShowCommand otherShowCommand = (ShowCommand) other;
+        return predicate.equals(otherShowCommand.predicate);
+    }
+
+    @Override
+    public int hashCode() {
+        return predicate.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("predicate", predicate)
+                .toString();
+    }
+}
+

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -18,6 +18,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.ShowCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -80,6 +81,8 @@ public class AddressBookParser {
 
         case CommentCommand.COMMAND_WORD:
             return new CommentCommandParser().parse(arguments);
+        case ShowCommand.COMMAND_WORD:
+            return new ShowCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/ShowCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ShowCommandParser.java
@@ -1,0 +1,39 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.Arrays;
+
+import seedu.address.logic.commands.ShowCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.group.GroupContainsKeywordsPredicate;
+
+/**
+ * Parses input arguments and creates a new ShowCommand object
+ */
+public class ShowCommandParser implements Parser<ShowCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the ShowCommand
+     * @param args String of arguments
+     * @return a ShowCommand object for execution
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ShowCommand parse(String args) throws ParseException {
+        try {
+            String trimmedArgs = args.trim();
+            String[] inputs = trimmedArgs.split(" ");
+            if (inputs.length != 1 || !trimmedArgs.matches("-?\\d+")) {
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, ShowCommand.MESSAGE_USAGE));
+            }
+            return new ShowCommand(new GroupContainsKeywordsPredicate(Arrays.asList(trimmedArgs)));
+        } catch (ParseException pe) {
+            String errorMessage = String.format("%s \n%s",
+                    pe.getMessage(),
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ShowCommand.MESSAGE_USAGE));
+            throw new ParseException(
+                    String.format(errorMessage), pe);
+        }
+    }
+}

--- a/src/main/java/seedu/address/model/group/Group.java
+++ b/src/main/java/seedu/address/model/group/Group.java
@@ -56,7 +56,7 @@ public class Group {
      * Format state as text for viewing.
      */
     public String toString() {
-        return '[' + groupName + ']';
+        return groupName;
     }
 
 }

--- a/src/main/java/seedu/address/model/group/GroupContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/group/GroupContainsKeywordsPredicate.java
@@ -1,0 +1,49 @@
+package seedu.address.model.group;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.person.Person;
+
+/**
+ * Tests that a {@code Person}'s {@code Group} matches any of the keywords given.
+ * Matching is case-insensitive and matches full words only.
+ */
+public class GroupContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywords;
+
+    public GroupContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        if (person.getGroup() == null) {
+            return false;
+        }
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getGroup().toString(), keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof GroupContainsKeywordsPredicate)) {
+            return false;
+        }
+
+        GroupContainsKeywordsPredicate otherGroupContainsKeywordsPredicate = (GroupContainsKeywordsPredicate) other;
+        return keywords.equals(otherGroupContainsKeywordsPredicate.keywords);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("keywords", keywords).toString();
+    }
+}

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -4,6 +4,7 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Objects;
 import java.util.Set;
 
@@ -72,6 +73,25 @@ public class Person {
      */
     public Set<Group> getGroups() {
         return Collections.unmodifiableSet(groups);
+    }
+
+    /**
+     * Retrieves the first {@link Group} from the set of groups.
+     *
+     * <p>This method returns the first element of the unmodifiable set of groups
+     * if available. If the set is empty, it returns {@code null}.</p>
+     *
+     * @return the first {@link Group} if it exists, or {@code null} if the set
+     *         of groups is empty.
+     *
+     */
+    public Group getGroup() {
+        Iterator<Group> iterator = getGroups().iterator();
+        if (iterator.hasNext()) {
+            return iterator.next(); // Returns the first element
+        } else {
+            return null;
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes #87 

There is no feature to easily find members of the same group

Let's add a command to show members of the same group

To use the command, type in `show [number]` where `[number]` is a compulsory field which corresponds to the group number you want to  show