### PR TITLE
Fix feature flaw for group

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -16,8 +16,8 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_DELETE_EMPTY_INDEX = "Error: The index cannot be empty";
-    public static final String MESSAGE_INVALID_NUMBER = "Invalid argument! Must be non-zero and "
-            + "positive integer (should not contain characters like '+')";
+    public static final String MESSAGE_INVALID_ARUGUMENTS = "Invalid arguments! "
+            + "Must be alphanumeric lowercase characters";
     public static final String MESSAGE_OVERFLOW_INDEX = "Error: Index is too large!"
                 + " The largest possible value is 2147483647.";
     public static final String MESSAGE_DELETE_UPPERBOUND_ERROR = "Sorry but the index was too large "
@@ -25,9 +25,11 @@ public class Messages {
     public static final String MESSAGE_DELETE_EMPTY_ERROR = "Sorry but you cannot delete from an empty list.";
 
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
-    public static final String MESSAGE_INVALID_NUMBER_OF_ARGS = "There should be one argument";
+    public static final String MESSAGE_INVALID_NUMBER_OF_ARGS = "There should be at least one argument";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
+    public static final String MESSAGE_MORE_THAN_FOUR_DUPLICATE_FIELDS =
+            "There should not be more than four duplicate fields for group (g/)";
     public static final String MESSAGE_NAME_CANNOT_BE_EMPTY = "Name cannot be empty.";
     public static final String MESSAGE_INVALID_STUDENT_ID_FORMAT = "Invalid Student ID format. It should be 9"
             + " characters with letters at the start and end, and digits in between (e.g., 'A1234567E').";

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -47,7 +47,7 @@ public class EditCommand extends Command {
             + "[" + PREFIX_NETID + "EMAIL] "
             + "[" + PREFIX_MAJOR + "MAJOR] "
             + "[" + PREFIX_YEAR + "YEAR] "
-            + "[" + PREFIX_GROUP + "TAG]...\n"
+            + "[" + PREFIX_GROUP + "GROUP]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_STUDENTID + "A1234567B "
             + PREFIX_NETID + "e1234567";
@@ -160,7 +160,7 @@ public class EditCommand extends Command {
             setStudentId(toCopy.studentId);
             setEmail(toCopy.email);
             setMajor(toCopy.major);
-            setTags(toCopy.groups);
+            setGroups(toCopy.groups);
             setYear(toCopy.year);
             setComment(toCopy.comment);
         }
@@ -218,10 +218,10 @@ public class EditCommand extends Command {
         }
 
         /**
-         * Sets {@code tags} to this object's {@code tags}.
-         * A defensive copy of {@code tags} is used internally.
+         * Sets {@code groups} to this object's {@code groups}.
+         * A defensive copy of {@code groups} is used internally.
          */
-        public void setTags(Set<Group> groups) {
+        public void setGroups(Set<Group> groups) {
             this.groups = (groups != null) ? new HashSet<>(groups) : null;
         }
 

--- a/src/main/java/seedu/address/logic/commands/ShowCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ShowCommand.java
@@ -18,9 +18,8 @@ public class ShowCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows all students in the same group "
             + "and displays them as a list with index numbers.\n"
-            + "Parameters: GROUP_NUMBER\n"
-            + "Only one number must be provided.\n"
-            + "Example: " + COMMAND_WORD + " 1";
+            + "Parameters: KEYWORDS\n"
+            + "Example: " + "group 1";
 
 
     private final Predicate<Person> predicate;

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -75,4 +75,17 @@ public class ArgumentMultimap {
             throw new ParseException(Messages.getErrorMessageForDuplicatePrefixes(duplicatedPrefixes));
         }
     }
+    /**
+     * Throws a {@code ParseException} if any of the prefixes given in {@code prefixes} appeared more than
+     * four times among the arguments.
+     */
+    public void verifyLessThanFourDuplicatePrefixesFor(Prefix... prefixes) throws ParseException {
+        long duplicateCount = Stream.of(prefixes)
+                .filter(argMultimap::containsKey)
+                .mapToLong(prefix -> argMultimap.get(prefix).size())
+                .sum();
+        if (duplicateCount > 4) {
+            throw new ParseException(Messages.MESSAGE_MORE_THAN_FOUR_DUPLICATE_FIELDS);
+        }
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -45,7 +45,8 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_STUDENTID, PREFIX_NETID,
-                PREFIX_MAJOR, PREFIX_YEAR, PREFIX_GROUP);
+                PREFIX_MAJOR, PREFIX_YEAR);
+        argMultimap.verifyLessThanFourDuplicatePrefixesFor(PREFIX_GROUP);
 
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
 
@@ -64,7 +65,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         if (argMultimap.getValue(PREFIX_MAJOR).isPresent()) {
             editPersonDescriptor.setMajor(ParserUtil.parseOptionalMajor(argMultimap.getValue(PREFIX_MAJOR).get()));
         }
-        parseTagsForEdit(argMultimap.getAllValues(PREFIX_GROUP)).ifPresent(editPersonDescriptor::setTags);
+        parseTagsForEdit(argMultimap.getAllValues(PREFIX_GROUP)).ifPresent(editPersonDescriptor::setGroups);
 
         if (!editPersonDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);

--- a/src/main/java/seedu/address/logic/parser/ShowCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ShowCommandParser.java
@@ -1,12 +1,14 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_INVALID_ARUGUMENTS;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.Messages.MESSAGE_INVALID_NUMBER;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_NUMBER_OF_ARGS;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.logging.Logger;
 
-import seedu.address.commons.util.StringUtil;
+import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.ShowCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.group.GroupContainsKeywordsPredicate;
@@ -15,6 +17,8 @@ import seedu.address.model.group.GroupContainsKeywordsPredicate;
  * Parses input arguments and creates a new ShowCommand object
  */
 public class ShowCommandParser implements Parser<ShowCommand> {
+    private static String VALIDATION_REGEX = "^[a-z0-9 ]*$";
+    private static final Logger logger = LogsCenter.getLogger(ShowCommandParser.class);
 
     /**
      * Parses the given {@code String} of arguments in the context of the ShowCommand
@@ -24,15 +28,18 @@ public class ShowCommandParser implements Parser<ShowCommand> {
      */
     public ShowCommand parse(String args) throws ParseException {
         try {
+            // Trim and prepare arguments
             String trimmedArgs = args.trim();
-            String[] inputs = trimmedArgs.split(" ");
-            if (inputs.length != 1 || inputs[0].isEmpty()) {
+            String[] inputs = trimmedArgs.split("\\s+");
+            List<String> keywords = Arrays.asList(inputs);
+            // Check if arguments are empty
+            if (inputs[0].isEmpty()) {
                 throw new ParseException(MESSAGE_INVALID_NUMBER_OF_ARGS);
             }
-            if (!StringUtil.isNonZeroUnsignedInteger(trimmedArgs)) {
-                throw new ParseException(MESSAGE_INVALID_NUMBER);
+            if (!trimmedArgs.matches(VALIDATION_REGEX)) {
+                throw new ParseException(MESSAGE_INVALID_ARUGUMENTS);
             }
-            return new ShowCommand(new GroupContainsKeywordsPredicate(Arrays.asList(trimmedArgs)));
+            return new ShowCommand(new GroupContainsKeywordsPredicate(keywords));
         } catch (ParseException pe) {
             String errorMessage = String.format("%s \n%s",
                     pe.getMessage(),

--- a/src/main/java/seedu/address/model/group/Group.java
+++ b/src/main/java/seedu/address/model/group/Group.java
@@ -13,8 +13,9 @@ import seedu.address.commons.core.LogsCenter;
  */
 public class Group {
 
-    public static final String MESSAGE_CONSTRAINTS = "Group is written as g/group [number] (in lowercase)";
-    public static final String VALIDATION_REGEX = "^group (?!0$)\\d+$";
+    public static final String MESSAGE_CONSTRAINTS = "Group is written as g/GROUP_NAME "
+            + "(less than 16 alphanumerical characters and in lowercase)";
+    public static final String VALIDATION_REGEX = "^[a-z0-9 ]{1,15}$";
     private static final Logger logger = LogsCenter.getLogger(Group.class);
     public final String groupName;
     /**

--- a/src/main/java/seedu/address/model/group/GroupContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/group/GroupContainsKeywordsPredicate.java
@@ -34,6 +34,11 @@ public class GroupContainsKeywordsPredicate implements Predicate<Person> {
             if (!Group.isValidGroupName(group.toString())) {
                 throw new ParseException(INVALID_GROUP);
             }
+            boolean prefixMatch = keywords.stream()
+                    .anyMatch(keyword -> group.toString().startsWith(keyword));
+            if (prefixMatch) {
+                return true;
+            }
             return keywords.stream()
                     .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getGroup().toString(), keyword));
         } catch (ParseException pe) {

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -27,8 +27,8 @@
           </minWidth>
         </Label>
         <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
-        <FlowPane fx:id="groups" maxWidth="50"/>
       </HBox>
+      <FlowPane fx:id="groups" />
       <Label fx:id="studentId" styleClass="cell_small_label" text="\$studentId" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
       <Label fx:id="major" styleClass="cell_small_label" text="\$major" />

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -71,10 +71,10 @@ public class CommandTestUtil {
     static {
         DESC_AMY = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)
                 .withStudentId(VALID_STUDENTID_AMY).withEmail(VALID_EMAIL_AMY).withAddress(VALID_MAJOR_AMY)
-                .withTags(VALID_TAG_FRIEND).build();
+                .withGroups(VALID_TAG_FRIEND).build();
         DESC_BOB = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB)
                 .withStudentId(VALID_STUDENTID_BOB).withEmail(VALID_EMAIL_BOB).withAddress(VALID_MAJOR_BOB)
-                .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
+                .withGroups(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -59,7 +59,7 @@ public class EditCommandTest {
                 .withTags(VALID_TAG_HUSBAND).build();
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB)
-                .withStudentId(VALID_STUDENTID_BOB).withTags(VALID_TAG_HUSBAND).build();
+                .withStudentId(VALID_STUDENTID_BOB).withGroups(VALID_TAG_HUSBAND).build();
         EditCommand editCommand = new EditCommand(indexLastPerson, descriptor);
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));

--- a/src/test/java/seedu/address/logic/commands/EditPersonDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditPersonDescriptorTest.java
@@ -54,7 +54,7 @@ public class EditPersonDescriptorTest {
         assertFalse(DESC_AMY.equals(editedAmy));
 
         // different tags -> returns false
-        editedAmy = new EditPersonDescriptorBuilder(DESC_AMY).withTags(VALID_TAG_HUSBAND).build();
+        editedAmy = new EditPersonDescriptorBuilder(DESC_AMY).withGroups(VALID_TAG_HUSBAND).build();
         assertFalse(DESC_AMY.equals(editedAmy));
     }
 

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -96,11 +96,11 @@ public class EditCommandParserTest {
         // while parsing {@code PREFIX_TAG} alone will reset the tags of the {@code Person} being edited,
         // parsing it together with a valid tag results in error
         assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_DESC_HUSBAND + TAG_EMPTY,
-                MESSAGE_MULTIPLE_GROUPS);
+                Group.MESSAGE_CONSTRAINTS);
         assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_EMPTY + TAG_DESC_HUSBAND,
-                MESSAGE_MULTIPLE_GROUPS);
+                Group.MESSAGE_CONSTRAINTS);
         assertParseFailure(parser, "1" + TAG_EMPTY + TAG_DESC_FRIEND + TAG_DESC_HUSBAND,
-                MESSAGE_MULTIPLE_GROUPS);
+                Group.MESSAGE_CONSTRAINTS);
 
         // multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser, "1" + INVALID_NAME_DESC + INVALID_EMAIL_DESC + VALID_MAJOR_AMY
@@ -116,7 +116,7 @@ public class EditCommandParserTest {
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)
                 .withStudentId(VALID_STUDENTID_BOB).withEmail(VALID_EMAIL_AMY).withAddress(VALID_MAJOR_AMY)
-                .withYear(VALID_YEAR_AMY).withTags(VALID_TAG_FRIEND).build();
+                .withYear(VALID_YEAR_AMY).withGroups(VALID_TAG_FRIEND).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
@@ -163,7 +163,7 @@ public class EditCommandParserTest {
 
         // tags
         userInput = targetIndex.getOneBased() + TAG_DESC_FRIEND;
-        descriptor = new EditPersonDescriptorBuilder().withTags(VALID_TAG_FRIEND).build();
+        descriptor = new EditPersonDescriptorBuilder().withGroups(VALID_TAG_FRIEND).build();
         expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
     }
@@ -191,7 +191,7 @@ public class EditCommandParserTest {
 
         assertParseFailure(parser, userInput,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_STUDENTID, PREFIX_NETID,
-                        PREFIX_MAJOR, PREFIX_GROUP));
+                        PREFIX_MAJOR));
 
         // multiple invalid values
         userInput = targetIndex.getOneBased() + INVALID_STUDENTID_DESC + INVALID_MAJOR_DESC + INVALID_EMAIL_DESC
@@ -206,7 +206,7 @@ public class EditCommandParserTest {
         Index targetIndex = INDEX_THIRD_PERSON;
         String userInput = targetIndex.getOneBased() + TAG_EMPTY;
 
-        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withTags().build();
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withGroups().build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);

--- a/src/test/java/seedu/address/logic/parser/ShowCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ShowCommandParserTest.java
@@ -18,25 +18,25 @@ public class ShowCommandParserTest {
 
     @Test
     public void parse_noPrefixesProvided_throwsParseException() {
-        assertParseFailure(parser, "", "There should be one argument \n"
+        assertParseFailure(parser, "", "There should be at least one argument \n"
                 + String.format(MESSAGE_INVALID_COMMAND_FORMAT, ShowCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void parse_emptyArg_throwsParseException() {
-        assertParseFailure(parser, "     ", "There should be one argument \n"
+        assertParseFailure(parser, "     ", "There should be at least one argument \n"
                 + String.format(MESSAGE_INVALID_COMMAND_FORMAT, ShowCommand.MESSAGE_USAGE));
     }
     @Test
     public void parse_negativeNumber_throwsParseException() {
-        assertParseFailure(parser, "-3", "Invalid argument! Must be non-zero and positive "
-                + "integer (should not contain characters like '+') \n"
+        assertParseFailure(parser, "-3", "Invalid arguments! Must be alphanumeric"
+                + " lowercase characters \n"
                 + String.format(MESSAGE_INVALID_COMMAND_FORMAT, ShowCommand.MESSAGE_USAGE));
     }
     @Test
     public void parse_specialSymbol_throwsParseException() {
-        assertParseFailure(parser, "%", "Invalid argument! Must be non-zero and positive "
-                + "integer (should not contain characters like '+') \n"
+        assertParseFailure(parser, "%", "Invalid arguments! Must be alphanumeric"
+                + " lowercase characters \n"
                 + String.format(MESSAGE_INVALID_COMMAND_FORMAT, ShowCommand.MESSAGE_USAGE));
     }
 

--- a/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
@@ -37,7 +37,7 @@ public class EditPersonDescriptorBuilder {
         descriptor.setStudentId(person.getStudentId());
         descriptor.setEmail(person.getEmail());
         descriptor.setMajor(person.getMajor());
-        descriptor.setTags(person.getGroups());
+        descriptor.setGroups(person.getGroups());
         descriptor.setYear(person.getYear());
     }
 
@@ -74,12 +74,12 @@ public class EditPersonDescriptorBuilder {
     }
 
     /**
-     * Parses the {@code tags} into a {@code Set<Tag>} and set it to the {@code EditPersonDescriptor}
+     * Parses the {@code groups} into a {@code Set<Group>} and set it to the {@code EditPersonDescriptor}
      * that we are building.
      */
-    public EditPersonDescriptorBuilder withTags(String... tags) {
-        Set<Group> groupSet = Stream.of(tags).map(Group::new).collect(Collectors.toSet());
-        descriptor.setTags(groupSet);
+    public EditPersonDescriptorBuilder withGroups(String... groups) {
+        Set<Group> groupSet = Stream.of(groups).map(Group::new).collect(Collectors.toSet());
+        descriptor.setGroups(groupSet);
         return this;
     }
 


### PR DESCRIPTION
Fixes #175 

To avoid flagged for overzealous inputs, let's:

* allow up to 4 groups to be tagged to a student

It is possible that one student is in different groups for different examinable components like CA1, CA2)

* do away with restrictions regarding group names

It is possible for students to want to have their own group names that are not e.g. "group 1"